### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     license='GPLv3',
     url='https://github.com/hasadna/knesset-data-django',
     packages=find_packages(exclude=["tests", "test.*"]),
-    install_requires=['knesset-data', 'django', 'datapackage'],
+    install_requires=['knesset-data', 'django', 'datapackage<1.0'],
 )


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.